### PR TITLE
updated cats, algebra and alleycats (not released yet)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For a new project, consider using [the activator template](https://github.com/ty
 The current list of dependencies and versions is:
 
 + [algebra-0.5.0](https://github.com/non/algebra)
-+ [alleycats-0.1.3](https://github.com/non/alleycats)
++ [alleycats-0.1.7](https://github.com/non/alleycats)
 + [catalysts-0.1.0](https://github.com/typelevel/catalysts)
 + [cats-0.7.2](https://github.com/typelevel/cats)
 + [discipline-0.5](https://github.com/typelevel/discipline)

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ For a new project, consider using [the activator template](https://github.com/ty
 
 The current list of dependencies and versions is:
 
-+ [algebra-0.4.2](https://github.com/non/algebra)
++ [algebra-0.5.0](https://github.com/non/algebra)
 + [alleycats-0.1.3](https://github.com/non/alleycats)
 + [catalysts-0.1.0](https://github.com/typelevel/catalysts)
-+ [cats-0.5.0](https://github.com/typelevel/cats)
++ [cats-0.7.2](https://github.com/typelevel/cats)
 + [discipline-0.5](https://github.com/typelevel/discipline)
 + [export-hook-1.1.0](https://github.com/milessabin/export-hook)
 + [kind-projector-0.7.1](https://github.com/non/kind-projector)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.12

--- a/src/main/scala/org/typelevel/TypelevelDeps.scala
+++ b/src/main/scala/org/typelevel/TypelevelDeps.scala
@@ -13,10 +13,10 @@ object Dependencies {
    * Format: Package -> version
    */
   val versions = Map[String, String](
-    "algebra"        -> "0.4.2",
-    "alleycats"      -> "0.1.3",
+    "algebra"        -> "0.5.0",
+    "alleycats"      -> "0.1.7",
     "catalysts"      -> "0.1.0",
-    "cats"           -> "0.5.0",
+    "cats"           -> "0.7.2",
     "discipline"     -> "0.5",
     "export-hook"    -> "1.1.0",
     "kind-projector" -> "0.7.1",
@@ -42,9 +42,8 @@ object Dependencies {
    * Format: Library name -> version key, org, library
    */
   val libraries = Map[String, (String, String, String)](
-    "algebra"               -> ("algebra"         , "org.spire-math"               , "algebra"),
-    "algebra-laws"          -> ("algebra"         , "org.spire-math"               , "algebra-laws"),
-    "algebra-std"           -> ("algebra"         , "org.spire-math"               , "algebra-std"),
+    "algebra"               -> ("algebra"         , "org.typelevel"               , "algebra"),
+    "algebra-laws"          -> ("algebra"         , "org.typelevel"               , "algebra-laws"),
     "alleycats"             -> ("alleycats"       , "org.typelevel"                , "alleycats"),
     "catalysts"             -> ("catalysts"       , "org.typelevel"                , "catalysts"),
     "catalysts-checklite"   -> ("catalysts"       , "org.typelevel"                , "catalysts-checklite"),
@@ -58,6 +57,7 @@ object Dependencies {
     "catalysts-testkit"     -> ("catalysts"       , "org.typelevel"                , "catalysts-testkit"),
     "cats"                  -> ("cats"            , "org.typelevel"                , "cats"),
     "cats-core"             -> ("cats"            , "org.typelevel"                , "cats-core"),
+    "cats-kernel"           -> ("cats"            , "org.typelevel"                , "cats-kernel"),
     "cats-free"             -> ("cats"            , "org.typelevel"                , "cats-free"),
     "cats-laws"             -> ("cats"            , "org.typelevel"                , "cats-laws"),
     "cats-macros"           -> ("cats"            , "org.typelevel"                , "cats-macros"),


### PR DESCRIPTION
please note that alleycats 0.1.7 is not released yet. I need to release this sbt-catalysts first to be able to release that, but if I leave the alleycats version as 0.1.6 here it will be incompatible with other dependencies. I'd rather release a temporarily not working one than something that introduces binary incomp. 