### PR TITLE
Excluding Transitive Dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ lazy val macros    = prj(macrosM)
 lazy val macrosJVM = macrosM.jvm
 lazy val macrosJS  = macrosM.js
 lazy val macrosM   = module("macros", CrossType.Pure)
-  .settings(typelevel.macroCompatSettings(vAll):_*)
+  .settings(macroCompatSettings(vAll):_*)
 
 /** Platform - cross project that provides cross platform support.*/
 lazy val platform    = prj(platformM)


### PR DESCRIPTION
This PR provides a couple of new methods to be able to exclude transitive dependencies. For instance:

```
.settings(
       addLibsExcluding(
          vAll,
          exclusions = List(
            ExclusionRule("org.scalaz", "scalaz-concurrent"),
            ExclusionRule("org.specs2", "specs2-matcher")
        ),
        "specs2-core","specs2-scalacheck" ):_*)
```
