### PR TITLE
refine xlint, added simulacrumSettings

### DIFF
--- a/src/main/scala/sbtcatalysts/CatalystsPlugin.scala
+++ b/src/main/scala/sbtcatalysts/CatalystsPlugin.scala
@@ -386,13 +386,20 @@ trait CatalystsBase {
     } yield Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", username, password)).toSeq
   )
 
-  lazy val xlint = Seq(
+  lazy val xlintSettings = Seq(
     scalacOptions += {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, 12)) => "-Xlint:-unused,_"  //Xling:unused warn against unused implicit evidence
         case _ => "-Xlint"
       }
     }
+  )
+
+  def simulacrumSettings(v: Versions) = Seq(
+    libraryDependencies ++= Seq(
+      "com.github.mpilquist" %%% "simulacrum" % v.vers("simulacrum") % "compile-time"),
+     ivyConfigurations += config("compile-time").hide,
+     unmanagedClasspath in Compile ++= update.value.select(configurationFilter("compile-time"))
   )
   // Builder methods
 

--- a/src/main/scala/sbtcatalysts/CatalystsPlugin.scala
+++ b/src/main/scala/sbtcatalysts/CatalystsPlugin.scala
@@ -230,8 +230,7 @@ trait CatalystsBase {
     "-deprecation",
     "-encoding", "UTF-8",
     "-feature",
-    "-unchecked",
-    "-Xlint"
+    "-unchecked"
   )
 
   /** Scalac options for additional language options.*/
@@ -387,6 +386,14 @@ trait CatalystsBase {
     } yield Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", username, password)).toSeq
   )
 
+  lazy val xlint = Seq(
+    scalacOptions += {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, 12)) => "-Xlint:-unused,_"  //Xling:unused warn against unused implicit evidence
+        case _ => "-Xlint"
+      }
+    }
+  )
   // Builder methods
 
   /**


### PR DESCRIPTION
in 2.12.2 `-Xlint` includes `unused` which checks unused imports, arguments, and variables. The unused arguments check is problematic as we often used implicit arguments as type evidence, e.g.  in cats, this option causes [these unwanted warnings](https://github.com/typelevel/cats/pull/1632#discussion_r113200950).
This change removed the `-Xlint` from `scalacAllOptions` and added a `xlint` settings val to enable `xlint` excluding the `unused` checks. 