### PR TITLE
remove scala 2.10 from crossScalaVersion

### DIFF
--- a/src/main/scala/sbtcatalysts/CatalystsPlugin.scala
+++ b/src/main/scala/sbtcatalysts/CatalystsPlugin.scala
@@ -358,7 +358,7 @@ trait CatalystsBase {
   def sharedBuildSettings(gh: GitHubSettings, v: Versions) = Seq(
     organization := gh.publishOrg,
     scalaVersion := v.vers("scalac"),
-    crossScalaVersions := Seq(v.vers("scalac_2.10"), v.vers("scalac_2.11"), scalaVersion.value)
+    crossScalaVersions := Seq(v.vers("scalac_2.11"), scalaVersion.value)
   )
 
   /**


### PR DESCRIPTION
It's time to say bye. 