### PR TITLE
Fix module name from vararg `addJava`

### DIFF
--- a/src/main/scala/org/typelevel/sbtcatalysts/Libraries.scala
+++ b/src/main/scala/org/typelevel/sbtcatalysts/Libraries.scala
@@ -41,7 +41,7 @@ case class Libraries(vers: VersionsType = Map(),
     add(name, version, org, LibrarySupport.ScalaJVM, modules:_*)
 
   def addJava(name: String, version: String, org: String, modules: String*): Libraries =
-    add(name, version, org, LibrarySupport.ScalaJVM, modules:_*)
+    add(name, version, org, LibrarySupport.Java, modules:_*)
 
   def add(name: String, version: String, org: String, librarySupport: LibrarySupport, modules: String*): Libraries =
     add(name, version)


### PR DESCRIPTION
Without this change, doing `addJava("foo", version, org, "lib1", "lib2")` would generate scala version name mangling for artifacts, rather than using the java module naming.